### PR TITLE
feat: Upgrade to @contentful/f36-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@contentful/app-sdk": "^4.29.7",
-        "@contentful/forma-36-react-components": "^3.100.7",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/f36-components": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/react-apps-toolkit": "^1.2.16",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^17.0.2",
@@ -64,7 +65,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -120,7 +120,6 @@
       "version": "7.27.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
       "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.27.5",
@@ -154,7 +153,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -196,7 +194,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -206,7 +203,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -240,7 +236,6 @@
       "version": "7.27.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
       "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.7"
@@ -504,7 +499,6 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -519,7 +513,6 @@
       "version": "7.27.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
       "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -538,7 +531,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -548,7 +540,6 @@
       "version": "7.27.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
       "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -574,58 +565,746 @@
         "contentful-management": "^11.52.1"
       }
     },
-    "node_modules/@contentful/forma-36-fcss": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
-      "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
+    "node_modules/@contentful/f36-accordion": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.80.4.tgz",
+      "integrity": "sha512-K4iJD1GEO8uUQKQ8zLDZMZqlQCV8MlU3Mn08Pk/uYlWD9Dh8b1z1cdfM0wTIqyEqQPNw/6H7aXxRNbtdxa/Iwg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.2"
+        "@contentful/f36-collapse": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/forma-36-react-components": {
-      "version": "3.100.7",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-react-components/-/forma-36-react-components-3.100.7.tgz",
-      "integrity": "sha512-7Auf4s6HOueifKOntbhFO6MjNMFyqGGHv53gxQsxR4hK+JJrEGqn2O37KFfgCYMsmRWVJzbuNEzHp4O91vEsxg==",
+    "node_modules/@contentful/f36-asset": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.80.4.tgz",
+      "integrity": "sha512-fSQEvbWqOL7x3gdBJZytKIOksIWVlyYmDEJr0zrKpb+JbzhGhoIU+iUExbcpbgactKH6YMXI+4FnczNApUOzcA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.3.4",
-        "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
-        "@popperjs/core": "^2.11.5",
-        "classnames": "^2.2.6",
-        "csstype": "^3.0.5",
-        "dayjs": "^1.9.1",
-        "react-animate-height": "^2.0.7",
-        "react-copy-to-clipboard": "^5.0.1",
-        "react-modal": "^3.11.2",
-        "react-popper": "^2.3.0",
-        "react-transition-group": "^4.4.2",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-autocomplete": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.80.4.tgz",
+      "integrity": "sha512-mT1zRZFaUZ3XdcGOz0Jo8rFNK9ggXGs0ExKUTf/ro8T1IJ38wf5r5sMNrxnD2ma/3de1O57AC4+T1D9Jo8ZcPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-forms": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.80.4",
+        "@contentful/f36-skeleton": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "downshift": "^6.1.12",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-avatar": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.80.4.tgz",
+      "integrity": "sha512-wClMXwEihL9obV1vbzerR+Ks56ypvvzfi1H3zX09pji8eShyxepwe8W0obrqS5NtAinc0gShEvOyTg4wM/lxRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-image": "4.80.4",
+        "@contentful/f36-menu": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-tooltip": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-badge": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.80.4.tgz",
+      "integrity": "sha512-c7uijWGTojbAUS/1G3mBDnwgWULCAAwZmAdoYn5q4Pms0yhy02FK2VqCSVxkS5zt6OR42SbvIgyLtIBBQj3TOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-button": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.80.4.tgz",
+      "integrity": "sha512-NXVGMXoIg3Cmi35AHnFViBBc244PtDi5TMGOIeJNyFtd8cJERnxj9XddvqwiMTXMjjnRuSbFaRgeQM/6EI9Qmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-spinner": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-tooltip": "^4.80.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-card": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.80.4.tgz",
+      "integrity": "sha512-oK8rkRSjkit+Lg9no3cA5n1J+QYBKM9tnqAOfJZk3P1j5tb85c1BulK76L2t9NROo/mkNsdFH59mj7dCak+rCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-asset": "^4.80.4",
+        "@contentful/f36-badge": "^4.80.4",
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-drag-handle": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.80.4",
+        "@contentful/f36-skeleton": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-tooltip": "^4.80.4",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/react-copy-to-clipboard": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
-      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+    "node_modules/@contentful/f36-collapse": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.80.4.tgz",
+      "integrity": "sha512-dD6WUMKmnmQh2OX6gAu8UWfO/iAfRS4kP5PTaxo/Uv/RK5FxqXcR/SmCLEvIQ0Zmk44YG0i/lLdfSDjHu5TqvQ==",
       "license": "MIT",
       "dependencies": {
-        "copy-to-clipboard": "^3.3.1",
-        "prop-types": "^15.8.1"
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": "^15.3.0 || 16 || 17 || 18"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw==",
+    "node_modules/@contentful/f36-components": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.80.4.tgz",
+      "integrity": "sha512-ouF7hklsDhX7AXm66USpaMjYtBSebIrFG3UTcFdltVbYW71I0DNhhzqu/c/NNuenf9cx/PYjnbuNHY7UNANgVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-accordion": "^4.80.4",
+        "@contentful/f36-asset": "^4.80.4",
+        "@contentful/f36-autocomplete": "^4.80.4",
+        "@contentful/f36-avatar": "4.80.4",
+        "@contentful/f36-badge": "^4.80.4",
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-card": "^4.80.4",
+        "@contentful/f36-collapse": "^4.80.4",
+        "@contentful/f36-copybutton": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-datepicker": "^4.80.4",
+        "@contentful/f36-datetime": "^4.80.4",
+        "@contentful/f36-drag-handle": "^4.80.4",
+        "@contentful/f36-empty-state": "^4.80.4",
+        "@contentful/f36-entity-list": "^4.80.4",
+        "@contentful/f36-forms": "^4.80.4",
+        "@contentful/f36-header": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.80.4",
+        "@contentful/f36-list": "^4.80.4",
+        "@contentful/f36-menu": "^4.80.4",
+        "@contentful/f36-modal": "^4.80.4",
+        "@contentful/f36-navbar": "^4.80.4",
+        "@contentful/f36-note": "^4.80.4",
+        "@contentful/f36-notification": "^4.80.4",
+        "@contentful/f36-pagination": "^4.80.4",
+        "@contentful/f36-pill": "^4.80.4",
+        "@contentful/f36-popover": "^4.80.4",
+        "@contentful/f36-skeleton": "^4.80.4",
+        "@contentful/f36-spinner": "^4.80.4",
+        "@contentful/f36-table": "^4.80.4",
+        "@contentful/f36-tabs": "^4.80.4",
+        "@contentful/f36-text-link": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-tooltip": "^4.80.4",
+        "@contentful/f36-typography": "^4.80.4",
+        "@contentful/f36-utils": "^4.24.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/f36-copybutton": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.80.4.tgz",
+      "integrity": "sha512-KNUxSHHE5tHQwS11RAUL9Lz9QyrMl8lpid7P0YTjyBTUNMz1Szw1mK0QFjRtxceOxI5R/hv5GhXekH2ezHKimg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-tooltip": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-core": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.80.4.tgz",
+      "integrity": "sha512-df8bJzUJnHBoC/TW857f0Dzl/faKVcIvifbALAhmiIjq/HwEbCPewQnqd0fF6XFnNU4B1/IHgNpCdxm+edyYFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.2.0",
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-datepicker": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.80.4.tgz",
+      "integrity": "sha512-6iXiTzshsgpIJfZwhtPK3UspQWZU3Yxc7ro2NopVUOxG8AQKNvBZcAxBpoplWaL0sH9G5ykvPwglM+OPR7R4nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-forms": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "date-fns": "^2.28.0",
+        "emotion": "^10.0.17",
+        "react-day-picker": "^8.7.1",
+        "react-focus-lock": "^2.9.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-datetime": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.80.4.tgz",
+      "integrity": "sha512-hrchnfxOgZODejweSVq8wAdY/eB3jJXWaze2kykxuxA4wKmy8MjjKw82uwN4sotVffCkMB3/qvz+8jHFNyqZYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "dayjs": "^1.11.5",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-drag-handle": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.80.4.tgz",
+      "integrity": "sha512-XwBC9xDGAXojxsjpnUSp1eeBwkG4GagUaPhf6T1un4HgsmreXdUzPtGKEjJjVu6kg65p71hvUuv94L8gyRlsYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-empty-state": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.80.4.tgz",
+      "integrity": "sha512-D3iNG2Qh1tVht801I/mt3smKM2SucYHs6OmAzfPR5htxFybTOnFVFP0f1nw4HwyWjZZRZQHNxhajAeXblVxQ4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-entity-list": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.80.4.tgz",
+      "integrity": "sha512-sKwLUMq/YDRs52MXckhz+IjR3fTzJ3a+owdxIv3OYn6IebDvWIof7Rfeqw3erzCsoXhqck8VaYgGdbiWSDVtxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-badge": "^4.80.4",
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-drag-handle": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.80.4",
+        "@contentful/f36-skeleton": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-forms": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.80.4.tgz",
+      "integrity": "sha512-+Do01OuKhvI+ILfHmvSj6NA9TpA+L9x+VBgpWthZQkZ5pcC02fDZK21MmPBzKeOJD/OXYYco8s9VgQHt1hbdjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-header": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.80.4.tgz",
+      "integrity": "sha512-kQhFRzbKJe5tEdWHnp95qUUUzb7g7dicKipY0aSe2AsG99zGerCpMjGGk04SlbAdb8UAsG2NqY41QW2F2kGG+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-icon": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.80.4.tgz",
+      "integrity": "sha512-OlPDLISuBZ16Vv4S86MYBmB+4kIXCEdm7ESk1t0hpsMZZBBs7T+G0PELF31OfR4E1SXcbrzN7fid6k/2/LOrUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-icons": {
+      "version": "4.29.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.1.tgz",
+      "integrity": "sha512-Klqewgt+CoU9BgWhVdFDEmQAWgI+KpsFYuYFsgdr7GCaMgHuecFSGN44SdW/bcv1Ijch3A1xEoYIOqTbLUAP7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-image": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.80.4.tgz",
+      "integrity": "sha512-thHX8g5Z5mjRhx5YK+f3tCMH+x1J8+GQ0RomZVVc3myxioVSay+TITPep1xnVIOxi6U/lhaSvsadGir9/zkj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-skeleton": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-list": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.80.4.tgz",
+      "integrity": "sha512-MficX3Jsivzxkbb7zhYVsIEscw9CnVKElY7asGyPSlRg3wwCZr/1Y9IeabCwwHBfJqpuDC9gCH195cQd4sOZpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-menu": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.80.4.tgz",
+      "integrity": "sha512-xJVFp3/LUt5yR8o2UGLBfkHl0L+DLJOZ6YR1dcQoLeghrC+BjmFv2JUQqHaEUfn7HA/bIg0q2JIL1doZQ7BVog==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-modal": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.80.4.tgz",
+      "integrity": "sha512-HJEm2+cdgZzXIyhIDShv6ro+lsxCqK+wvVDHb0x9sKtuMQpx7pqIP8dwMOMNc3KauVJB/IYjhYou00ojAxX8vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "@types/react-modal": "^3.13.1",
+        "emotion": "^10.0.17",
+        "react-modal": "^3.16.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-navbar": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.80.4.tgz",
+      "integrity": "sha512-eFbG3f+913Q1BatNf/1HQRqIjacqFUk8PRXh9S75o4b0vhoQY7f4ddfKgfIFFJ7p9AhTRKQ3dSj/w6f7AA3V8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-avatar": "4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.80.4",
+        "@contentful/f36-skeleton": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-note": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.80.4.tgz",
+      "integrity": "sha512-qAwtG2XFaGwT/DbRqgLN/ltwg0NrSWvEr2DceYiPkpExSUXwiU8uVLmKFA+e06yfFq2htT4J3mvKmPxVJ7K4TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icon": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-notification": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.80.4.tgz",
+      "integrity": "sha512-Nlmb5fpAFHlRX6nXRI/PmSfTbc2RXo0TZh09qTTdt5+PnTRChGx5MV8b3KA1XD0g3S864vi4JkVbTzxlWEKtJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17",
+        "react-animate-height": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-pagination": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.80.4.tgz",
+      "integrity": "sha512-D7MhdZvBAecJkszEKmZbRk4vrUN+5RZ3INurZ6rLEw+6f+lFgh9HgDbQ/+2lg9xzsinjsufjX9RqqgskCU5lKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-forms": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-pill": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.80.4.tgz",
+      "integrity": "sha512-IQeSiTytaOOwJYmhDsbZO00jTBJeId1vpdny3eQKr5biKy3AWkH27omv01hmZadiaAFGD4fVAKgrWEbiscRjEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^4.80.4",
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-drag-handle": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-tooltip": "^4.80.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-popover": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.80.4.tgz",
+      "integrity": "sha512-kYoW4itBG4CSsf5mzKP4Utq/9BwNxHB8pVCgfasu9oCMCPlmpUj520Ho8isEZwf4MEjoL1yqDITVhqNsHzu3cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-utils": "^4.24.3",
+        "@popperjs/core": "^2.11.5",
+        "emotion": "^10.0.17",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-skeleton": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.80.4.tgz",
+      "integrity": "sha512-FbkTSWrK461dIaxTkIU2Bef0ZXmltKs1O2Eag4IPtALQf++Vq4wfSxg47kfgOgEg0ErAqPyybOewnKz24c2f7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-table": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-spinner": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.80.4.tgz",
+      "integrity": "sha512-o7w8NFQl3vNGhgHiSOE3hU+ZZ9otq8z3hiqWRAif9Pg2rU2rP8S0vSp+yEWDpum2v1y6hMeSVW93QP5qlGj0TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-table": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.80.4.tgz",
+      "integrity": "sha512-+1taInIjALot6K/F4wzxJ85zCBAhue17b40zNtUO4NbNR7a5gN4IE6do9tRw4ll+Drs6KMpxJQDCMJQHKG/VYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-typography": "^4.80.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-tabs": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.80.4.tgz",
+      "integrity": "sha512-T+ANnFf+aZ1XRhK5Kat3DHx7n/Rs7H5RuVRO3IqdFMIf5OuR0VSefS0ir/WIUOnw8ZM6aoaZePSonGEXrFRcmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@radix-ui/react-tabs": "^1.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-text-link": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.80.4.tgz",
+      "integrity": "sha512-mXGRF9aqvXCPkMD645ccdiLgM9HnfKEWlK7bz7ILEEGnrvOYyTMArs77Q2dzoLSvZTrHW0BeHU56G1KnvSgYTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-tokens": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
+      "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ==",
       "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tooltip": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.80.4.tgz",
+      "integrity": "sha512-gwNnGtM1p89EgnV5ZO880VBGs2ibyNZn/q/GV09W4h5marEdQIQ/sA6fIKoJnkY/CB+V4fniesI5j8OvuB80oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-utils": "^4.24.3",
+        "@popperjs/core": "^2.11.5",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-typography": {
+      "version": "4.80.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.80.4.tgz",
+      "integrity": "sha512-vucWdlCMaKtVWbZAZ/ENDPJYavfW+s5rGZoBb1yY61fZlDg/mN/HL/vq59SG/nBbNKJ2RehDGQH5krbQ4s2H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^4.80.4",
+        "@contentful/f36-tokens": "^4.2.0",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-utils": {
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.3.tgz",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
+      "license": "MIT",
+      "dependencies": {
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/react-apps-toolkit": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.16.tgz",
+      "integrity": "sha512-vx7+T4h+w1XBbn7OfRoXr8YUTtiyRNLaltF2ziM4xMqBryu/3Y71nBbhbxD6NIfOui3QIo3TR9Q5sPTZvGbIVw==",
+      "license": "MIT",
+      "dependencies": {
+        "contentful-management": ">=7.30.0"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": ">=4.0.0",
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.8.5",
@@ -784,6 +1463,122 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "node_modules/@emotion/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/serialize/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1204,7 +1999,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -1219,7 +2013,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1229,7 +2022,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1239,14 +2031,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1298,6 +2088,294 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
+      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
+      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
@@ -1456,6 +2534,12 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -1472,6 +2556,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1906,6 +2999,81 @@
         "@babel/core": "^7.11.0"
       }
     },
+    "node_modules/babel-plugin-emotion": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
+      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/babel-plugin-istanbul": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
@@ -1937,6 +3105,30 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.1.0",
@@ -2108,7 +3300,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2193,12 +3384,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -2329,6 +3514,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2378,13 +3569,35 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/create-emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
       "license": "MIT",
       "dependencies": {
-        "toggle-selection": "^1.0.6"
+        "@emotion/cache": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
       }
     },
     "node_modules/cross-spawn": {
@@ -2436,6 +3649,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -2446,7 +3675,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2511,14 +3739,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/downshift": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -2585,6 +3825,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2602,7 +3852,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -2811,6 +4060,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2823,6 +4078,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/focus-lock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/follow-redirects": {
@@ -3161,6 +4428,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3214,8 +4506,22 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -4112,7 +5418,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4125,7 +5430,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -4155,7 +5459,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -4343,7 +5646,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -4534,11 +5836,22 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -4596,6 +5909,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -4620,11 +5939,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -4718,6 +6045,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4780,20 +6113,42 @@
       }
     },
     "node_modules/react-animate-height": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.1.2.tgz",
-      "integrity": "sha512-A9jfz/4CTdsIsE7WCQtO9UkOpMBcBRh8LxyHl2eoZz1ki02jpyUL5xt58gabd0CyeLQ8fRyQ+s2lyV2Ufu8Owg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.1"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "react": ">=15.6.2",
-        "react-dom": ">=15.6.2"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -4816,10 +6171,33 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
     },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.6.tgz",
+      "integrity": "sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
@@ -4859,22 +6237,6 @@
         "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4883,6 +6245,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -5301,6 +6683,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -5425,12 +6819,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "license": "MIT"
-    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -5549,9 +6937,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5661,6 +7047,49 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -5944,6 +7373,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   "homepage": "https://github.com/mvikrammenon/contentful-schema-validate#readme",
   "dependencies": {
     "@contentful/app-sdk": "^4.29.7",
-    "@contentful/forma-36-react-components": "^3.100.7",
-    "@contentful/forma-36-tokens": "^0.11.2",
+    "@contentful/f36-components": "^4.80.4",
+    "@contentful/f36-tokens": "^4.2.0",
+    "@contentful/react-apps-toolkit": "^1.2.16",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^17.0.2",

--- a/src/components/BentoLayoutValidator.tsx
+++ b/src/components/BentoLayoutValidator.tsx
@@ -5,9 +5,10 @@ import {
   Paragraph,
   List,
   ListItem,
-  Card as FormaCard, // Renaming to avoid conflict with CardEntry
+  Card as F36Card, // Renaming to avoid conflict with CardEntry
   Stack,
-} from '@contentful/forma-36-react-components';
+  Text, // For stronger text, replacing Paragraph with strong
+} from '@contentful/f36-components';
 import { PlainClientAPI } from 'contentful-management'; // Using PlainClientAPI for type
 import { Entry } from 'contentful'; // For Entry type
 
@@ -149,7 +150,7 @@ const BentoLayoutValidator: React.FC = () => {
 
   if (errorParsingLayout) {
     return (
-      <Note noteType="negative" title="Configuration Error">
+      <Note variant="negative" title="Configuration Error">
         {errorParsingLayout}
       </Note>
     );
@@ -159,7 +160,7 @@ const BentoLayoutValidator: React.FC = () => {
      // This case should ideally be covered by errorParsingLayout,
      // but as a fallback:
     return (
-      <Note noteType="warning" title="Configuration Missing">
+      <Note variant="warning" title="Configuration Missing">
         Bento layout configuration is not available. Cannot perform validation.
       </Note>
     );
@@ -168,25 +169,25 @@ const BentoLayoutValidator: React.FC = () => {
   return (
     <Stack flexDirection="column" spacing="spacingS" fullWidth>
       {validationErrors.length === 0 && (
-        <Note noteType="positive">
+        <Note variant="positive">
           Bento layout is valid!
         </Note>
       )}
       {validationErrors.length > 0 && (
-        <FormaCard testId="validation-errors-card">
-          <Paragraph>
-            <strong>Validation Issues:</strong>
-          </Paragraph>
-          <List>
+        <F36Card testId="validation-errors-card">
+          <Text fontWeight="fontWeightDemiBold" as="p" marginBottom="spacingS">
+            Validation Issues:
+          </Text>
+          <List style={{ listStyle: 'none', paddingLeft: 0}}>
             {validationErrors.map((error, index) => (
-              <ListItem key={index}>
-                <Note noteType={error.type === 'error' ? 'negative' : 'warning'}>
+              <ListItem key={index} style={{ marginBottom: 'var(--spacing-xs)'}}>
+                <Note variant={error.type === 'error' ? 'negative' : 'warning'}>
                   {error.message}
                 </Note>
               </ListItem>
             ))}
           </List>
-        </FormaCard>
+        </F36Card>
       )}
        {/* Display current layout and cards for debugging/transparency */}
        {/* <details>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,14 +3,18 @@ import { render } from 'react-dom';
 import { SDKProvider } from '@contentful/react-apps-toolkit';
 
 import BentoLayoutValidator from './components/BentoLayoutValidator';
-import { GlobalStyles } from '@contentful/forma-36-react-components';
+// GlobalStyles from f36-components is usually not needed when using SDKProvider,
+// as SDKProvider or the host environment often takes care of base styling.
+// If specific global styles are needed, they can be imported from @contentful/f36-components/GlobalStyles
+// import { GlobalStyles } from '@contentful/f36-components';
+
 
 const root = document.getElementById('root');
 
 if (root) {
   render(
     <SDKProvider>
-      <GlobalStyles />
+      {/* <GlobalStyles />  // Typically not needed with f36 and SDKProvider */}
       <BentoLayoutValidator />
     </SDKProvider>,
     root


### PR DESCRIPTION
- Replaced older `@contentful/forma-36-react-components` and `@contentful/forma-36-tokens` with newer `@contentful/f36-components` and `@contentful/f36-tokens`.
- Refactored `BentoLayoutValidator.tsx` to use equivalent components and props from the f36 library (e.g., `Note` variant, `Text` component).
- Updated `index.tsx` to remove redundant `GlobalStyles` as `SDKProvider` handles base f36 styling.
- Documentation in README (provided manually to user) updated to reflect the use of f36 components.